### PR TITLE
ft/1275 Documet `creds` function and fix some warnings

### DIFF
--- a/dsa/dimensijos.rst
+++ b/dsa/dimensijos.rst
@@ -1471,6 +1471,64 @@ prepare
 
             {"request_model": {"param1": "first", "param2": "value2", "param3": None}}
 
+
+.. function:: creds(key)
+
+    Skaito kliento duomenyse išsaugoto `key` atributo reikšmę.
+
+    Kliento duomenyse kiekvieno resurso atributai saugomi atskirai. Resursas identifikuojamas
+    pagal resurso pavadinimą.
+
+    **Argumentai**
+
+    key
+        Nurodo atributo pavadinimą kliento faile.
+
+    .. admonition:: Pavyzdys (be URI parametrų)
+
+        **Kliento failas:**
+
+        .. code-block:: yaml
+
+            client_id: 75d17c2f-d7b8-466f-90c7-466caa21582a
+            client_name: example_client
+            client_secret_hash: hashed_secret
+            scopes:
+              - spinta_getall
+            backends:
+              resource_one:
+                password: first password
+              resource_two:
+                password: second password
+
+        Kliento duomenyse yra išsaugoti resursai: `resource_one` ir `resource_two`. Abu resursai turi po atributą
+        tuo pačiu vardu `password`, bet skirtingomis reikšmėmis.
+
+        **DSA:**
+
+        ============= ======= ======== ====== =========== ===================== ===========================
+        resource      model   property type   ref         source                 prepare
+        ============= ======= ======== ====== =========== ===================== ===========================
+        resource_one                   soap               \https://example.com/
+        \                              param  parameter1  param1                `creds("password").input()`
+        \             Town
+        resource_two                   soap               \https://example.com/
+        \                              param  parameter2  param2                `creds("password").input()`
+        \             City
+        ============= ======= ======== ====== =========== ===================== ===========================
+        |
+
+        Pagal pateiktą DSA, Spinta užklausos metu, `creds()` funkcija iš kliento duomenų perskaitys
+        `password` reikšmes ir `input()` funkcijos pagalba, sugeneruos tokius Python dictionary:
+
+        * Kviečiant `Town`: `{"param1": "first password"}`
+        * Kviečiant `City`: `{"param2": "second password"}`
+
+        Apie kliento duomenų saugojimą daugiau skaityti Duomenų atvėrimo vadove, `Klientų atnaujinimas`_.
+
+        .. _Klientų atnaujinimas: https://atviriduomenys.readthedocs.io/agentas.html#agent-crud-update
+
+
 .. _switch:
 
 switch

--- a/dsa/formatas.rst
+++ b/dsa/formatas.rst
@@ -232,11 +232,11 @@ pavadinimą, pavyzdžiui :data:`model.ref`, kas reikštų, kad kalbama apie
     siekiant identifikuoti konkrečias metaduomenų eilutes, kad būtų galima atpažinti metaduomenis,
     kurie jau buvo pateikti ir po to atnaujinti.
 
-    :term:`SDSA` leidžiama naudoti lokalų šaltinio identifikatorių - tai gali būti sveikasis, monotoniškai didėjantis
+    :term:`ŠDSA` leidžiama naudoti lokalų šaltinio identifikatorių - tai gali būti sveikasis, monotoniškai didėjantis
     skaičius ar bet koks kitas unikalus identifikatorius.
 
     Viešai publikuojamame :term:`DSA` privaloma naudoti tik globaliai unikalų :rfc:`UUID <9562>`.
-    Pateikus :term:`SDSA` į duomenų katalogą, lokalus identifikatorius automatiškai pakeičiamas į :rfc:`UUID <9562>`.
+    Pateikus :term:`ŠDSA` į duomenų katalogą, lokalus identifikatorius automatiškai pakeičiamas į :rfc:`UUID <9562>`.
 
     Šio stulpelio pildyti nereikia.
 

--- a/dsa/index.rst
+++ b/dsa/index.rst
@@ -41,7 +41,7 @@ kur ir kaip duomenys yra saugomi ir kaip juos pasiekti. Schema apibrėžianti
 duomenų modelį priklauso nuo duomenų saugojimo formato. Jei duomenys saugomi
 SQL duomenų bazėse, tada DSA lentelėje nurodomi lentelių ir stulpelių
 pavadinimai, XML atveju nurodomos XPath_ išraiškos, JSON atveju nurodomos
-JSONPath_ išraiškos. DSA lentelėje fizinis modelis nurodomas :ref:`source`
+JSONPath_ išraiškos. DSA lentelėje fizinis modelis nurodomas :data:`source`
 stulpelyje.
 
 :dfn:`Loginis modelis` yra duomenų schema, kuri naudojama duomenų apsikeitimui

--- a/dsa/modelis.rst
+++ b/dsa/modelis.rst
@@ -378,7 +378,7 @@ property
 
 type
     Duomenų tipas, žiūrėti :ref:`duomenų-tipai`. UML diagramose, jei duomenų
-    tipas yra :data:`ref` arba :data:`backref`, tada nurodomas modelio
+    tipas yra `ref` arba `backref`, tada nurodomas modelio
     pavadinimas, URI forma, su kuriuo daroma asociacija.
 
 cardinality


### PR DESCRIPTION
**Summary:**
* Documents `creds()` prepare function
* Fixes some warnings that was bothering me

**Ticket:**
https://github.com/atviriduomenys/spinta/issues/1275


## Other errors:

There are still some warnings showed when using `make auto`. I will gladly fix them if someone will tell me how to, since I'm not very familiar with Sphinx documentation.

```
dsa/formatas.rst:25: WARNING: image file not readable: _static/struktura.png [image.not_readable]
dsa/index.rst:31: WARNING: image file not readable: _static/dsa_overview.png [image.not_readable]
dsa/modelis.rst:28: WARNING: image file not readable: _static/VSSA-UML-template-example.svg [image.not_readable]
dsa/modelis.rst:236: WARNING: image file not readable: _static/modelis.png [image.not_readable]
```
**Reason:** (most likely): All images are stored in `static/` instead of `_static/`, but images are displayed anyways

```
dsa/branda/L000.rst: WARNING: document isn't included in any toctree
dsa/branda/L100.rst: WARNING: document isn't included in any toctree
dsa/branda/L200.rst: WARNING: document isn't included in any toctree
dsa/branda/L300.rst: WARNING: document isn't included in any toctree
dsa/branda/L400.rst: WARNING: document isn't included in any toctree
dsa/branda/L500.rst: WARNING: document isn't included in any toctree
```
**Reason:** (most likely): files in `dsa/branda/*` directory are not in any `toctree`, but file `dsa/branda.rst` has same or very similar information and it's included in `toctree`. So, are files inside `dsa/branda/*`not used? Was there an attempt to split `branda.rst`, but never finished? Is it something else?

```
dsa/modelis.rst:538: WARNING: term not in glossary: 'sąvoka' [ref.term]
```
**Reason:** (most likely) no term in glossary. Either add it to glossary or remove the link

